### PR TITLE
allow skipping author match + skip GPT scoring for author-matched papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It filters out any `UPDATED` papers and announces only new ones.
 
 The filtering logic is pretty simple. We first check for author match.
 1. Do a lookup of the authors on semantic scholar, getting a list of candidate matches.
-2. Check the authors of the paper. If the author semantic scholar id matches someone in `authors.txt` it goes in the candidate set with a default score of `author_match_score`. These papers with matched authors will not go through the next stage of GPT scoring. 
+2. Check the authors of the paper. If the author semantic scholar id matches someone in `authors.txt` it goes in the candidate set with a default score of `author_match_score`.
 
 We then check for GPT-evaluated relevance. We do this in two steps.
 1. Filter out any papers that have no authors with h-index above `hcutoff` in `config.ini`. This is to reduce costs.
@@ -107,7 +107,7 @@ The NOVELTY should be a score from 1 to 10, where 10 is a groundbreaking, genera
 4. Papers are filtered if they have scores below either the relevance and novelty cutoffs in `config.ini`
 5. Papers are given an overall score based on equal weight to relevance and novelty
 
-Finally, both the author-matched and GPT evaluated papers are sorted by the score (for papers with author-match, we use the `author_match_score`; for others, we use the sum of the GPT-rated relevance and novelty scores for sorting) and the papers are rendered and pushed into their endpoints (text files or Slack).
+Finally, all papers are sorted by the max of their `author_match_score` and the sum of the GPT-rated relevance and novelty scores (the relevance and novelty scores will only show up in the final output if they are above the cutoff thresholds you set in the config file). Then the papers are rendered and pushed into their endpoints (text files or Slack).
 
 ## Contributing 
 This repo uses ruff - `ruff check .` and `ruff format .` 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It filters out any `UPDATED` papers and announces only new ones.
 
 The filtering logic is pretty simple. We first check for author match.
 1. Do a lookup of the authors on semantic scholar, getting a list of candidate matches.
-2. Check the authors of the paper. If the author semantic scholar id matches someone in `authors.txt` it goes in the candidate set with a default score of `author_match_score`.
+2. Check the authors of the paper. If the author semantic scholar id matches someone in `authors.txt` it goes in the candidate set with a default score of `author_match_score`. These papers with matched authors will not go through the next stage of GPT scoring. 
 
 We then check for GPT-evaluated relevance. We do this in two steps.
 1. Filter out any papers that have no authors with h-index above `hcutoff` in `config.ini`. This is to reduce costs.
@@ -107,7 +107,7 @@ The NOVELTY should be a score from 1 to 10, where 10 is a groundbreaking, genera
 4. Papers are filtered if they have scores below either the relevance and novelty cutoffs in `config.ini`
 5. Papers are given an overall score based on equal weight to relevance and novelty
 
-Finally, both the author-matched and GPT evaluated papers are sorted by the score and the papers are rendered and pushed into their endpoints (text files or Slack).
+Finally, both the author-matched and GPT evaluated papers are sorted by the score (for papers with author-match, we use the `author_match_score`; for others, we use the sum of the GPT-rated relevance and novelty scores for sorting) and the papers are rendered and pushed into their endpoints (text files or Slack).
 
 ## Contributing 
 This repo uses ruff - `ruff check .` and `ruff format .` 

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -19,6 +19,8 @@ num_samples = 1
 hcutoff = 15
 relevance_cutoff = 3
 novelty_cutoff = 3
+# whether to do author matching
+author_match = true
 
 [OUTPUT]
 debug_messages = true

--- a/filter_papers.py
+++ b/filter_papers.py
@@ -232,14 +232,16 @@ def filter_by_gpt(
                     >= int(config["FILTERING"]["relevance_cutoff"])
                     and jdict["NOVELTY"] >= int(config["FILTERING"]["novelty_cutoff"])
                     and jdict["ARXIVID"] in all_papers
-                    ## only add if not covered by author-match yet
-                    and jdict["ARXIVID"] not in selected_papers 
                 ):
                     selected_papers[jdict["ARXIVID"]] = {
                         **dataclasses.asdict(all_papers[jdict["ARXIVID"]]),
                         **jdict,
                     }
-                    sort_dict[jdict["ARXIVID"]] = jdict["RELEVANCE"] + jdict["NOVELTY"]
+                    ## take the max of author match and gpt score
+                    sort_dict[jdict["ARXIVID"]] = max(
+                        jdict["RELEVANCE"] + jdict["NOVELTY"],
+                        sort_dict.get(jdict["ARXIVID"], 0),
+                    )
                 scored_in_batch.append(
                     {
                         **dataclasses.asdict(all_papers[jdict["ARXIVID"]]),


### PR DESCRIPTION
Minor changes:

1. Added a flag in the config file to allow users to skip the author-matching part if they want to.
2. For papers with matched author(s), skip the GPT scoring step (so the author match scores won't be overwritten). 
3. Edited the README file to clarify this. 