### PR TITLE
prepend 'user-content-' to in-text links to match the prepended 'user-content-' in link anchors when rendered by Github Pages

### DIFF
--- a/parse_json_to_md.py
+++ b/parse_json_to_md.py
@@ -37,7 +37,9 @@ def render_paper(paper_entry: dict, idx: int) -> str:
 def render_title_and_author(paper_entry: dict, idx: int) -> str:
     title = paper_entry["title"]
     authors = paper_entry["authors"]
-    paper_string = f"{idx}. [{title}](#link{idx})\n"
+    # Github Pages seems to prepend 'user-content-' to the above anchors,
+    # so adjust for that and prepend 'user-content' to the in-text links
+    paper_string = f"{idx}. [{title}](#user-content-link{idx})\n" 
     paper_string += f'**Authors:** {", ".join(authors)}\n'
     return paper_string
 


### PR DESCRIPTION
in-text links don't point to their respective anchors in the text, because somehow the anchors are rendered as 'user-content-link{idx}' instead of 'link{idx}'